### PR TITLE
fix: allow `docker build` to take up to 40 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - env: PLATFORM="x86_64"
 
 script:
-  - docker build --rm -t quay.io/pypa/manylinux1_$PLATFORM:$TRAVIS_COMMIT -f docker/Dockerfile-$PLATFORM docker/
+  - travis_wait 40 docker build --rm -t quay.io/pypa/manylinux1_$PLATFORM:$TRAVIS_COMMIT -f docker/Dockerfile-$PLATFORM docker/
 
 
 deploy:


### PR DESCRIPTION
This PR proposes adding a [`travis_wait`](https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received) instruction to `docker build` within the travis config file. Assuming that building the container takes less than 40 minutes, the Travis build should pass.